### PR TITLE
Ignore local uploads directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.quarto/
 useR2024.html
 useR2024_files
+uploads


### PR DESCRIPTION
The MP4 is unsurprisingly large, but the generated PDF version of the slides is also larger than I want in the repo.